### PR TITLE
fix: Handle possibly `None` value of `job.retries_left` attribute

### DIFF
--- a/rq/registry.py
+++ b/rq/registry.py
@@ -274,7 +274,7 @@ class StartedJobRegistry(BaseRegistry):
                     if job.meta:
                         if ret := job.meta.get('_retried_after_abandonned', 0) < MAX_RETRIES_AFTER_ABANDONED:
                             job.meta['_retried_after_abandonned'] = ret + 1
-                            job.retries_left = getattr(job, 'retries_left', 0) + 1
+                            job.retries_left = (getattr(job, 'retries_left', 0) or 0) + 1
                         else :
                             logger.error(
                                 f'{self.__class__.__name__} retried to restart {MAX_RETRIES_AFTER_ABANDONED} times the job {job.id} after AbandonedJobError, giving up. Still {job.retries_left} retries left.'


### PR DESCRIPTION
`job.retries_left` is `Optional` and may be `None`, thus `getattr(job, 'retries_left', 0)` may return `None`.
It returns the default value `0` only if there is no `retries_left` attribute on `job`.