### PR TITLE
Fix error when retries == None

### DIFF
--- a/rq/registry.py
+++ b/rq/registry.py
@@ -274,7 +274,7 @@ class StartedJobRegistry(BaseRegistry):
                     if job.meta:
                         if ret := job.meta.get('_retried_after_abandonned', 0) < MAX_RETRIES_AFTER_ABANDONED:
                             job.meta['_retried_after_abandonned'] = ret + 1
-                            job.retries_left = getattr(job, 'retries_left', 0) + 1
+                            job.retries_left = (getattr(job, 'retries_left', None) or 0) + 1
                         else :
                             logger.error(
                                 f'{self.__class__.__name__} retried to restart {MAX_RETRIES_AFTER_ABANDONED} times the job {job.id} after AbandonedJobError, giving up. Still {job.retries_left} retries left.'


### PR DESCRIPTION
In some case, job.retries_left actually existed, but set to None. It would crash when trying to add +1. This fixes it by defaulting to 0 always.

[See the error here](https://app.datadoghq.eu/logs?query=pod_name%3Aapp-z0f5e2104-backend-fr-prod-worker-58995d8bf-8hp2q%20status%3Aerror&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AgAAAZC-McmEKv__OgAAAAAAAAAYAAAAAEFaQy1NZFdBQUFBazNsRnZ1c0s4dWdBVQAAACQAAAAAMDE5MGJlMzQtMGE2My00ZTc4LWEyYmUtMDE5YjBmOWM0Y2Q1&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1721175230890&to_ts=1721179601475&live=false)
The slack [thread here](https://alanhealth.slack.com/archives/C19FZEB41/p1721317525816009?thread_ts=1719842140.557849&cid=C19FZEB41)