### PR TITLE
Increase number of of max retroes after abandoned

### DIFF
--- a/rq/registry.py
+++ b/rq/registry.py
@@ -23,7 +23,7 @@ from .utils import as_text, backend_class, current_timestamp
 logger = logging.getLogger("rq.registry")
 
 
-MAX_RETRIES_AFTER_ABANDONED=2
+MAX_RETRIES_AFTER_ABANDONED=10
 
 class BaseRegistry:
     """


### PR DESCRIPTION
## Why

_Always_ retry when a job is killed because a worker is shutdown (deployment and cluster down scale)

### Context

Jobs are sometimes repeatedly killed because of worker shutdowns
- For critical tasks (like Noemie or Almerys file import), we will be alerted but it delays processing as an eng then needs to relaunch a retry manually 
- For less critical tasks (like cache update), it's never retried.

### Past cases 

It has been identified as the **most frequent case of Noemie file import incident root cause**. [Retrospective](https://www.notion.so/alaninsurance/Retrospective-of-neomie-file-processing-incidents-3b6dc485fa9a463ba54004196197ee8c?pvs=4#80c6c025d50145689b619a8d81b1d60b)

[**All recent cases**](https://app.datadoghq.eu/logs?query=status%3Aerror%20AbandonedJobError%2C%20giving%20up.%20Still%200%20retries%20left.%20&agg_m=count&agg_m_source=base&agg_t=count&cols=core_host%2Ccore_service%2C%40job.id&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1720965941408&to_ts=1722261941408&live=true) (on last 15 days):
- July 29 (critical): TP file import
- July 22 (critical): TP file import [thread](https://alanhealth.slack.com/archives/C01Q794KWGG/p1721728803350649)
- July 20 (critical): TP rights update. Out of the X `_tp_rights_daily_updates` jobs started this day, two never completed because of this, so it delayed TP rights opening/closing for some members 
- July 20: 292 cache updates
- July 19: 1 insurance document parsing
- July 17 (critical): TP file import

## Quick solution

Increase the number of max retries after abandoned added by https://github.com/alan-eu/rq/pull/9

Drawback: If a job is retried a lot of time (because it was repeatedly killed), it will delays the processing time. 

## Better solution? (not implemented here)

https://github.com/alan-eu/rq/pull/14#issuecomment-2259935307

Instead of having this logic in this repo that retries when a job is "Abandoned", could we have a logic that ALWAYS retry when a job failed because of `rq. exceptions.ShutDownImminentException`?

The exception is raised [here](https://github.com/alan-eu/rq/blob/b6fb879fdc488dba6f4c73bd2b5249559019a128/rq/worker.py#L1622-L1625). I guess we could implement an `on_failure` handler in our jobs to catch `ShutDownImminentException` and always retry. wdyt?