### PR TITLE
pass the queue class from the worker to the sceduler so that it can use something else than Queue

### DIFF
--- a/rq/scheduler.py
+++ b/rq/scheduler.py
@@ -45,6 +45,7 @@ class RQScheduler:
         date_format=DEFAULT_LOGGING_DATE_FORMAT,
         log_format=DEFAULT_LOGGING_FORMAT,
         serializer=None,
+        queue_class=None,
     ):
         self._queue_names = set(parse_names(queues))
         self._acquired_locks: Set[str] = set()
@@ -65,6 +66,7 @@ class RQScheduler:
             log_format=log_format,
             date_format=date_format,
         )
+        self.queue_class = queue_class or Queue
 
     @property
     def connection(self):
@@ -146,7 +148,8 @@ class RQScheduler:
             if not job_ids:
                 continue
 
-            queue = Queue(registry.name, connection=self.connection, serializer=self.serializer)
+            queue_cls = self.queue_class
+            queue = queue_cls(registry.name, connection=self.connection, serializer=self.serializer)
 
             with self.connection.pipeline() as pipeline:
                 jobs = Job.fetch_many(job_ids, connection=self.connection, serializer=self.serializer)

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -778,6 +778,7 @@ class BaseWorker:
             date_format=date_format,
             log_format=log_format,
             serializer=self.serializer,
+            queue_class=self.queue_class
         )
         self.scheduler.acquire_locks()
         if self.scheduler.acquired_locks:


### PR DESCRIPTION
### TL;DR
Added support for custom queue classes in the RQ scheduler

### What changed?
- Added a `queue_class` parameter to the Scheduler's initialization
- Modified the scheduler to use the provided queue class when enqueueing scheduled jobs
- Updated the worker to pass its queue class to the scheduler

### How to test?
1. Create a custom Queue class that extends the base Queue
2. Initialize a Scheduler with the custom queue class
3. Schedule jobs and verify they are enqueued using the custom queue class
4. Alternatively, initialize a Worker with a custom queue class and verify the scheduler uses it

### Why make this change?
This change enables users to customize queue behavior in scheduled jobs, maintaining consistency with any queue class customizations used elsewhere in their RQ implementation. This is particularly useful when specific queue implementations are needed for different use cases or environments.