### PR TITLE
when cancelling a job, make sure it's saved to Redis first

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -1185,6 +1185,9 @@ class Job:
         """
         if self.is_canceled:
             raise InvalidJobOperation("Cannot cancel already canceled job: {}".format(self.get_id()))
+        # make sure the job exists in Redis
+        if not self.exists(self.id, self.connection):
+            self.save()
         from .queue import Queue
         from .registry import CanceledJobRegistry
 


### PR DESCRIPTION
We had errors with jobs in Redis only containing `{'status': b'canceled'}`, no other keys/data. It turns out that these errors only happen for cancelled jobs.
The [cancel](https://github.com/alan-eu/rq/blob/alan/rq/job.py#L1168) method in RQ (original code) has a bug: it calls `self.set_status(JobStatus.CANCELED, pipeline=pipe)`  which changes the status of the job python object (in memory), but it also sets the status in Redis, doing a simple `hset` , only setting the "status" hash key, not the rest, (i.e. not the data)
It works well most of the time, when you cancel a job that has already been saved in Redis.
But if you do: _"create a Job (only in memory) ▶️  cancel it immediately"_ then the result is that an entry in Redis is created, with only `{'status': b'canceled'}` , no properly saved job.
The problem lies in the `cancel` method from RQ, which doesn't check that the job exists in Redis before changing its status.
This fixes the issue by making sure that the job exists in Redis before cancelling it