### PR TITLE
fix: make Job.fetch_many resilient to corrupted jobs

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -645,14 +645,14 @@ class Job:
                 jobs.append(None)
                 continue
 
+            job = None
             try:
                 job = cls(job_id, connection=connection, serializer=serializer)
                 job.restore(results[i])
-                jobs.append(job)
             except Exception:
                 logger.error("RQ Scheduler Error: corrupted job %s in fetch_many, skipping. Raw keys: %s",
                              job_id, list(results[i].keys()), exc_info=True)
-                jobs.append(None)
+            jobs.append(job)
 
         return jobs
 

--- a/rq/job.py
+++ b/rq/job.py
@@ -645,9 +645,14 @@ class Job:
                 jobs.append(None)
                 continue
 
-            job = cls(job_id, connection=connection, serializer=serializer)
-            job.restore(results[i])
-            jobs.append(job)
+            try:
+                job = cls(job_id, connection=connection, serializer=serializer)
+                job.restore(results[i])
+                jobs.append(job)
+            except Exception:
+                logger.error("RQ Scheduler Error: corrupted job %s in fetch_many, skipping. Raw keys: %s",
+                             job_id, list(results[i].keys()), exc_info=True)
+                jobs.append(None)
 
         return jobs
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -198,6 +198,19 @@ class TestJob(RQTestCase):
         jobs = Job.fetch_many([job.id, job2.id, 'invalid_id'], self.testconn)
         self.assertEqual(jobs, [job, job2, None])
 
+    def test_fetch_many_corrupted_job(self):
+        """Corrupted jobs (missing data key) should return None, not crash."""
+        job = Job.create(func=fixtures.some_calculation, args=(3, 4), kwargs=dict(z=2), connection=self.testconn)
+        job.save()
+
+        corrupted_id = "corrupted-job"
+        self.testconn.hset(Job.key_for(corrupted_id), "status", "scheduled")
+
+        jobs = Job.fetch_many([corrupted_id, job.id], self.testconn)
+        self.assertEqual(len(jobs), 2)
+        self.assertIsNone(jobs[0])
+        self.assertEqual(jobs[1], job)
+
     def test_persistence_of_empty_jobs(self):  # noqa
         """Storing empty jobs."""
         job = Job()


### PR DESCRIPTION
## 🤓 Why

The RQ scheduler crashed for ~3 days because a corrupted job in Redis (only `status: scheduled`, missing `data` payload) caused `Job.fetch_many()` → `job.restore()` → `NoSuchJobError`, killing the scheduler process.

PR #28 fixed the enqueue side. This fixes the fetch side so corrupted jobs are skipped gracefully.

## 💪 How

- Wrap the `restore()` call in `fetch_many` with a try/except
- On failure: log an error with the job ID and raw keys, return `None` (consistent with the existing behavior for missing jobs)

## ⚠️ Beware!

No monitoring/alert in Datadog when finding the 'RQ scheduler Error' in the logs => if we want to reduce noise for oncall, we might not want to add such alerts, but I have no strong opinion on this 

## 😇 Test

- [x] unit test
- [ ] CI (linters, existing unit tests, etc.)
- [ ] locally
- [ ] storybook
- [ ] accessibility ([checklist](https://www.notion.so/alaninsurance/1141426e8be780aa8273d7d5f8c9fcf7))
- [ ] bug squashed with a designer/PM
- [ ] documentation/comment change only
- [ ] migration PR
- [ ] not tested, indicate reason:

<details><summary><h4>📚 Documentation</h4></summary>

* [Code Review at Alan](https://www.notion.so/alaninsurance/2f614324b74848d6b88b0d6e58a3b87f)
* Command to lint errors (ruff, prettier, djlint) `@alan-bot fix ci`

</details>