### PR TITLE
fix: walrus precedence in abandoned-job retry cap

### DIFF
--- a/rq/registry.py
+++ b/rq/registry.py
@@ -274,7 +274,7 @@ class StartedJobRegistry(BaseRegistry):
 
                     # we did a job fetch so the meta is supposed to be there
                     if job.meta:
-                        if ret := job.meta.get('_retried_after_abandonned', 0) < MAX_RETRIES_AFTER_ABANDONED:
+                        if (ret := job.meta.get('_retried_after_abandonned', 0)) < MAX_RETRIES_AFTER_ABANDONED:
                             job.meta['_retried_after_abandonned'] = ret + 1
                             job.retries_left = (getattr(job, 'retries_left', 0) or 0) + 1
                         else :


### PR DESCRIPTION
> 🤖 This PR was generated with [Claude Code](https://claude.com/claude-code).

## Summary

Fixes a walrus-operator-precedence bug in `StartedJobRegistry.cleanup` that silently disables the `MAX_RETRIES_AFTER_ABANDONED` cap. Abandoned jobs end up looping indefinitely instead of being capped after `MAX_RETRIES_AFTER_ABANDONED` cleanup passes.

## The bug

In [`rq/registry.py`](https://github.com/alan-eu/rq/blob/alan/rq/registry.py#L277):

```python
if ret := job.meta.get('_retried_after_abandonned', 0) < MAX_RETRIES_AFTER_ABANDONED:
    job.meta['_retried_after_abandonned'] = ret + 1
    ...
```

`<` has higher precedence than `:=`, so Python parses this as `if (ret := (counter < MAX)):`. `ret` ends up bound to the **boolean** result of the comparison (`True` / `False`), not to the counter. Since `True + 1 = 2` and `False + 1 = 1`, the counter stored back to Redis oscillates between 1 and 2 forever, and `counter < MAX` stays true → the cap never fires.

## Why it stayed latent for a year

The original [PR #9](https://github.com/alan-eu/rq/pull/9) set `MAX = 2`. With the bug, the counter writes back as `True+1=2` on the first pass; the second pass evaluates `(2 < 2) = False`, falls to the `else` branch, and the standard `retries_left > 0` check then routes the job to `FailedJobRegistry`. So with `MAX = 2` the loop terminated after one retry — by accident.

When [PR #14](https://github.com/alan-eu/rq/pull/14) raised `MAX` to `10` in July 2024 (to give critical jobs like Noemie / TP imports more retries on deploy-driven kills), the comparison started returning `True` forever and the latent bug became the infinite loop now observed.

## Observed impact downstream

Surfaced in alan-eu/alan-apps as [INF-1778](https://linear.app/alan-eu/issue/INF-1778) / [incident-2026-05-20](https://alanhealth.slack.com/archives/C0B4ZE68GB0). The kill mechanism today is no longer the original "deploy kills worker" case (those have proper grace periods now) but **container-level OOM** (k8s 1.28+ defaults to `memory.oom.group=true`, so worker + horse die together and no Python code runs to decrement `retries_left`). The orphan then flows through `StartedJobRegistry.cleanup` — straight into the broken cap.

Concrete symptom: one stuck `insurance_document_id` bounced across **117 distinct worker pods in 2 days**.

[alan-apps PR #92875](https://github.com/alan-eu/alan-apps/pull/92875) addresses the SIGTERM path (worker shutting down gracefully). This PR fixes the residual SIGKILL path that flows through the registry cleanup.

## Note on prior reasoning

Worth flagging that the failure mode this PR fixes was anticipated. On PR #14, @dams [explicitly noted](https://github.com/alan-eu/rq/pull/14#issuecomment-2258133205): *"We thought about it but I'm not a big fan (actually quite against it 😅) as it can lead to infinite retries, and clogging the queues."* The cap was the safety net to prevent exactly that; it just didn't work as intended because of the walrus precedence.

## The fix

```diff
-                        if ret := job.meta.get('_retried_after_abandonned', 0) < MAX_RETRIES_AFTER_ABANDONED:
+                        if (ret := job.meta.get('_retried_after_abandonned', 0)) < MAX_RETRIES_AFTER_ABANDONED:
```

cc @dams @zallek since this touches code you both worked on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)